### PR TITLE
Update Dockerfiles (back to 1.10.0) to use rustup installer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,6 @@ env:
     - VERSION=1.10.0 VARIANT=
     - VERSION=1.10.0 VARIANT=slim
     - VERSION=1.10.0 VARIANT=musl
-    - VERSION=1.9.0 VARIANT=
-    - VERSION=1.9.0 VARIANT=slim
-    - VERSION=1.9.0 VARIANT=musl
-    - VERSION=1.8.0 VARIANT=
-    - VERSION=1.8.0 VARIANT=slim
-    - VERSION=1.8.0 VARIANT=musl
-    - VERSION=1.7.0 VARIANT=
-    - VERSION=1.7.0 VARIANT=slim
-    - VERSION=1.6.0 VARIANT=
-    - VERSION=1.6.0 VARIANT=slim
-    - VERSION=1.5.0 VARIANT=
-    - VERSION=1.5.0 VARIANT=slim
-    - VERSION=1.4.0 VARIANT=
-    - VERSION=1.4.0 VARIANT=slim
-    - VERSION=1.3.0 VARIANT=
-    - VERSION=1.3.0 VARIANT=slim
-    - VERSION=1.2.0 VARIANT=
-    - VERSION=1.2.0 VARIANT=slim
 
 before_script:
   - env | sort

--- a/1.10.0/Dockerfile
+++ b/1.10.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.10.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.10.0/musl/Dockerfile
+++ b/1.10.0/musl/Dockerfile
@@ -7,25 +7,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.10.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.10.0/musl/build_musl.sh
+++ b/1.10.0/musl/build_musl.sh
@@ -6,7 +6,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 # in https://github.com/asaaki/rust-musl/blob/master/tools/scripts/build.sh.
 # Very many thanks!
 
-: ${MUSL_VERSION:=1.1.14}
+: ${MUSL_VERSION:=1.1.16}
 : ${BUILDROOT:=/prep}
 
 musl_root=/usr/local/musl

--- a/1.10.0/slim/Dockerfile
+++ b/1.10.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.10.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.11.0/Dockerfile
+++ b/1.11.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.11.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.11.0/musl/Dockerfile
+++ b/1.11.0/musl/Dockerfile
@@ -6,26 +6,21 @@ RUN apt-get update \
     gdb \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUST_VERSION 1.11.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
+ENV RUST_VERSION 1.15.0
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.11.0/musl/build_musl.sh
+++ b/1.11.0/musl/build_musl.sh
@@ -6,7 +6,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 # in https://github.com/asaaki/rust-musl/blob/master/tools/scripts/build.sh.
 # Very many thanks!
 
-: ${MUSL_VERSION:=1.1.14}
+: ${MUSL_VERSION:=1.1.16}
 : ${BUILDROOT:=/prep}
 
 musl_root=/usr/local/musl

--- a/1.11.0/slim/Dockerfile
+++ b/1.11.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.11.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.12.0/Dockerfile
+++ b/1.12.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.12.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.12.0/musl/Dockerfile
+++ b/1.12.0/musl/Dockerfile
@@ -7,25 +7,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.12.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.12.0/musl/build_musl.sh
+++ b/1.12.0/musl/build_musl.sh
@@ -6,7 +6,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 # in https://github.com/asaaki/rust-musl/blob/master/tools/scripts/build.sh.
 # Very many thanks!
 
-: ${MUSL_VERSION:=1.1.14}
+: ${MUSL_VERSION:=1.1.16}
 : ${BUILDROOT:=/prep}
 
 musl_root=/usr/local/musl

--- a/1.12.0/slim/Dockerfile
+++ b/1.12.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.12.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.13.0/Dockerfile
+++ b/1.13.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.13.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.13.0/musl/Dockerfile
+++ b/1.13.0/musl/Dockerfile
@@ -7,25 +7,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.13.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.13.0/musl/build_musl.sh
+++ b/1.13.0/musl/build_musl.sh
@@ -6,7 +6,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 # in https://github.com/asaaki/rust-musl/blob/master/tools/scripts/build.sh.
 # Very many thanks!
 
-: ${MUSL_VERSION:=1.1.15}
+: ${MUSL_VERSION:=1.1.16}
 : ${BUILDROOT:=/prep}
 
 musl_root=/usr/local/musl

--- a/1.13.0/slim/Dockerfile
+++ b/1.13.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.13.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.14.0/Dockerfile
+++ b/1.14.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.14.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.14.0/musl/Dockerfile
+++ b/1.14.0/musl/Dockerfile
@@ -7,25 +7,20 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.14.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.14.0/musl/build_musl.sh
+++ b/1.14.0/musl/build_musl.sh
@@ -6,7 +6,7 @@ if [ -n "${DEBUG:-}" ]; then set -x; fi
 # in https://github.com/asaaki/rust-musl/blob/master/tools/scripts/build.sh.
 # Very many thanks!
 
-: ${MUSL_VERSION:=1.1.15}
+: ${MUSL_VERSION:=1.1.16}
 : ${BUILDROOT:=/prep}
 
 musl_root=/usr/local/musl

--- a/1.14.0/slim/Dockerfile
+++ b/1.14.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.14.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.15.0/Dockerfile
+++ b/1.15.0/Dockerfile
@@ -7,15 +7,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.15.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.15.0/musl/Dockerfile
+++ b/1.15.0/musl/Dockerfile
@@ -6,26 +6,21 @@ RUN apt-get update \
     gdb \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUST_VERSION 1.14.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
-RUN URL=http://static.rust-lang.org/dist/rust-std-${RUST_VERSION}-x86_64-unknown-linux-musl.tar.gz \
-  && mkdir -p /prep/rust-std-musl \
-  && (cd /prep && curl -LO $URL) \
-  && tar xf /prep/$(basename $URL) -C /prep/rust-std-musl --strip-components=1 \
-  && (cd /prep/rust-std-musl && ./install.sh --prefix=$(rustc --print sysroot))
-
-COPY build_musl.sh /prep/build_musl.sh
-RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep
-
-ENV PATH $PATH:/usr/local/musl/bin
+ENV RUST_VERSION 1.15.0
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
+COPY build_musl.sh /prep/build_musl.sh
+RUN BUILDROOT=/prep bash /prep/build_musl.sh && rm -rf /prep \
+  && env -u CARGO_HOME rustup target add x86_64-unknown-linux-musl
+ENV PATH $PATH:/usr/local/musl/bin
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/1.15.0/slim/Dockerfile
+++ b/1.15.0/slim/Dockerfile
@@ -15,15 +15,15 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 ENV RUST_VERSION 1.15.0
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --revision=$RUST_VERSION \
-  && rustc --version && cargo --version
-
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/nightly/Dockerfile
+++ b/nightly/Dockerfile
@@ -6,16 +6,16 @@ RUN apt-get update \
     gdb \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUST_CHANNEL nightly
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --channel=$RUST_CHANNEL \
-  && rustc --version && cargo --version
-
+ENV RUST_VERSION nightly
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]

--- a/nightly/slim/Dockerfile
+++ b/nightly/slim/Dockerfile
@@ -14,16 +14,16 @@ RUN apt-get update \
     make \
   && rm -rf /var/lib/apt/lists/*
 
-ENV RUST_CHANNEL nightly
-
-RUN curl -s https://static.rust-lang.org/rustup.sh \
-  | sh -s -- --yes --disable-sudo --channel=$RUST_CHANNEL \
-  && rustc --version && cargo --version
-
+ENV RUST_VERSION nightly
 ENV CARGO_HOME /cargo
+ENV PATH $CARGO_HOME/bin:/root/.cargo/bin:$PATH
 ENV SRC_PATH /src
 
-RUN mkdir -p "$CARGO_HOME" "$SRC_PATH"
+RUN curl -sSf https://sh.rustup.rs \
+  | env -u CARGO_HOME sh -s -- -y --default-toolchain "$RUST_VERSION" \
+  && rustc --version && cargo --version \
+  && mkdir -p "$CARGO_HOME" "$SRC_PATH"
+
 WORKDIR $SRC_PATH
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
This change also drops rebuilding of images older than version 1.10.0 of
Rust. Future changes will seek to only keep a fixed number of recent
releases being updated.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>